### PR TITLE
Document theme description feature

### DIFF
--- a/customising-the-view/index.md
+++ b/customising-the-view/index.md
@@ -23,6 +23,8 @@ This is done exactly like the regular configuration, within the same configurati
 | `googleAnalytics`   | String  | &mdash;                 |
 | `trackingCode`      | String  | &mdash;                 |
 | `sort`              | Array   | &mdash;                 |
+| `description`       | String  | &mdash;                 |
+| `descriptionPath`   | String  | &mdash;                 |
 
 ## Visibility display
 
@@ -119,6 +121,26 @@ sort:
 {% endhighlight %}
 
 This will sort the data by access (public first, then private, `access>` would have inverted the order), then by descending line (last items in the file first), then by alphetical group (case insensitive), then by file.
+
+## Description
+
+You can define a complete description of your project (unlike `package.description` which is a short overview). It is parsed as Markdown.
+
+{% highlight yaml %}
+description: |
+  This is the description of the project!
+
+  * It is parsed as markdown.
+  * It is displayed in your documentation page.
+{% endhighlight %}
+
+## Description path
+
+If you prefer to externalize the description in a file, you can use the `descriptionPath` option, which will populate (or overwrite) the `description` option. It is relative to the configuration file, and parsed as Markdown.
+
+{% highlight yaml %}
+descriptionPath: ../README.md
+{% endhighlight %}
 
 ## Example
 

--- a/extra-tools/index.md
+++ b/extra-tools/index.md
@@ -133,3 +133,15 @@ module.exports = function (dest, ctx) {
 {% endhighlight %}
 
 {% include routes.html %}
+
+## Description
+
+The `description` filter introduces a `description` and `descriptionPath` configuration keys. The first is a raw description text, the second is a path to a file to find the description text (and will override the `description` key).
+
+{% highlight js %}
+{
+  descriptionPath: '../README.md',
+}
+{% endhighlight %}
+
+The `descriptionPath` is relative to the configuration file, and have no required format. However the `markdown` filter will be happy to parse the description as Markdown if called **after** `description`.


### PR DESCRIPTION
* See SassDoc/sassdoc-extras#18

Need to be merged in both `master` and `develop` once the description feature is merged inside the default theme and published.