### PR TITLE
Fix default values

### DIFF
--- a/customising-the-view/index.md
+++ b/customising-the-view/index.md
@@ -18,11 +18,11 @@ This is done exactly like the regular configuration, within the same configurati
 | `display.access`    | Array   | `["public", "private"]` |
 | `display.alias`     | Boolean | `false`                 |
 | `display.watermark` | Boolean | `true`                  |
-| `basePath`          | String  | `""`                    |
-| `shortcutIcon`      | String  | `""`                    |
-| `googleAnalytics`   | String  | `""`                    |
-| `trackingCode`      | String  | `""`                    |
-| `sort`              | Array   |                         |
+| `basePath`          | String  | &mdash;                 |
+| `shortcutIcon`      | String  | &mdash;                 |
+| `googleAnalytics`   | String  | &mdash;                 |
+| `trackingCode`      | String  | &mdash;                 |
+| `sort`              | Array   | &mdash;                 |
 
 ## Visibility display
 


### PR DESCRIPTION
There is no default value for `basePath`, `shortcutIcon`, `googleAnalytics` and `trackingCode`. They are never set to an empty string. They're only tested to be falsy (including undefined key, which is the "default value").