### PR TITLE
File annotations docs to match parser behavior

### DIFF
--- a/file-level-annotations/index.md
+++ b/file-level-annotations/index.md
@@ -7,7 +7,7 @@ title: "File-level annotations"
 
 You can define annotations at a file-level rather than on specific items. It is useful when you have a whole file sharing some annotations (for instance `@group`, `@author` and so on).
 
-Usually, the *poster comment* goes on top of the file. In order to be parsed as a poster, it has to be prefixed by `////`. You should have 4 slashes on the first and last lines (which are usually empty lines), and any number of slashes in between (2, 3, 4...). See example below. Also, you cannot have more than on poster per file.
+Usually, the *poster comment* goes on top of the file. In order to be parsed as a poster, it has to be prefixed by `////`. You should have 4 slashes on the first and last lines (which are usually empty lines), and any number of slashes in between (3, 4, 5...). See example below. Also, you cannot have more than one poster per file.
 
 Feel free to add a description to it, however it won't be parsed in any way. For now, it is nothing but a comment. [At some point](https://github.com/SassDoc/sassdoc/issues/256), it might be useful though.
 


### PR DESCRIPTION
A typo fix snuck in with this, but mostly to address the sassdoc issue cited.

Closes SassDoc/sassdoc#454