### PR TITLE
Fix hex code for brand tertiary color

### DIFF
--- a/brand-guidelines/index.md
+++ b/brand-guidelines/index.md
@@ -38,7 +38,7 @@ $code-font-stack: 'Courier New', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono',
 
     <li class="color  color--tertiary">
         <span class="color__name">$tertiary-color</span>
-        <span class="color__value">#135c6a</span>
+        <span class="color__value">#5c4863</span>
     </li>
 
     <li class="color  color--black">


### PR DESCRIPTION
The current hex code listed in the docs doesn't match the actual (desired) color:
![image](https://user-images.githubusercontent.com/4576234/89344040-424ac180-d673-11ea-9bd1-4215f3d5cbb5.png)
