### PR TITLE
fix: webpack loader recommendations

### DIFF
--- a/webpack/index.md
+++ b/webpack/index.md
@@ -8,14 +8,21 @@ title: "Webpack integration"
 There are a couple of community provided packages for easing SassDoc integration with [Webpack](https://webpack.js.org/). Please note those are not projects maintained nor supported by the SassDoc team, refer to the corresponding repositories for issues.
 
 
-[`sassdoc-loader`](https://github.com/allanhortle/sassdoc-loader)
+[`@advclb/sassdoc-loader`](https://github.com/advclb/sassdoc-loader)
+
+{% highlight sh %}
+npm install --save-dev @advclb/sassdoc-loader
+{% endhighlight %}
+
+
+[`sassdoc-loader`](https://github.com/allanhortle/sassdoc-loader) (archived)
 
 {% highlight sh %}
 npm install --save-dev sassdoc-loader
 {% endhighlight %}
 
 
-[`@domjtalbot/sassdoc-loader`](https://github.com/domjtalbot/sassdoc-loader)
+[`@domjtalbot/sassdoc-loader`](https://github.com/domjtalbot/sassdoc-loader) (archived)
 
 {% highlight sh %}
 npm install --save-dev @domjtalbot/sassdoc-loader


### PR DESCRIPTION
- add the only up-to-date package to the top of the list;
- add "(archived)" to others.